### PR TITLE
Add stack.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ cabal.sandbox.config
 __pycache__
 *~
 *.kvs
+.stack-work
 
 # vim swapfiles
 *.sw*

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+flags: {}
+packages:
+- '.'
+extra-deps: []
+resolver: lts-3.0


### PR DESCRIPTION
So people can build using Stack or Cabal, whichever they prefer. Might as well use modern tooling, I suppose.
